### PR TITLE
use_python3 option

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,4 +19,5 @@ build:
         clear_pybuild_dir: false
         clean_debian_rules: false
         stdeb_command: bdist_deb
+        use_python3: false
 ```

--- a/README.md
+++ b/README.md
@@ -18,6 +18,6 @@ build:
         clear_debian_dir: false
         clear_pybuild_dir: false
         clean_debian_rules: false
-        stdeb_command: bdist_deb
+        stdeb_command: bdist_deb --with-python3=True
         use_python3: false
 ```

--- a/run.sh
+++ b/run.sh
@@ -29,7 +29,7 @@ cd ${WERCKER_PYTHON_STDEB_PROJECT_ROOT}
 
 (set -x; ${PYTHON_INTERP} setup.py --command-package=stdeb.command ${WERCKER_PYTHON_STDEB_STDEB_COMMAND})
 
-if [ "${WERCKER_PYTHON_STDEB_STDEB_COMMAND}" == "debianize" ]; then
+if [[ "${WERCKER_PYTHON_STDEB_STDEB_COMMAND}" =~ ^debianize.* ]]; then
   sed -i -e "s/-1)/-${NOW})/" debian/changelog
 fi
 

--- a/run.sh
+++ b/run.sh
@@ -9,32 +9,27 @@ PYBUILD_DIR="${WERCKER_PYTHON_STDEB_PROJECT_ROOT}/.pybuild"
 
 if [ "${WERCKER_PYTHON_STDEB_CLEAR_DEBIAN_SOURCE_DIR}" != "false" ]; then
   if [ -e ${DEBIAN_SOURCE_DIR} ]; then
-    echo "rm -rf ${DEBIAN_SOURCE_DIR}"
-    rm -rf ${DEBIAN_SOURCE_DIR}
+    (set -x; rm -rf ${DEBIAN_SOURCE_DIR})
   fi
 fi
 
 if [ "${WERCKER_PYTHON_STDEB_CLEAR_PYBUILD_DIR}" != "false" ]; then
   if [ -e ${PYBUILD_DIR} ]; then
-    echo "rm -rf ${PYBUILD_DIR}"
-    rm -rf ${PYBUILD_DIR}
+    (set -x; rm -rf ${PYBUILD_DIR})
   fi
 fi
 
 NOW=$(date -u +'%Y%m%dT%H%M%SZ')
 cd ${WERCKER_PYTHON_STDEB_PROJECT_ROOT}
 
-echo "python setup.py --command-package=stdeb.command ${WERCKER_PYTHON_STDEB_STDEB_COMMAND}"
-python setup.py --command-package=stdeb.command ${WERCKER_PYTHON_STDEB_STDEB_COMMAND}
+(set -x; python setup.py --command-package=stdeb.command ${WERCKER_PYTHON_STDEB_STDEB_COMMAND})
 
 if [ "${WERCKER_PYTHON_STDEB_STDEB_COMMAND}" == "debianize" ]; then
   sed -i -e "s/-1)/-${NOW})/" debian/changelog
 fi
 
 if [ "$WERCKER_PYTHON_STDEB_CLEAN_DEBIAN_RULES" != "false" ]; then
-  echo "fakeroot debian/rules clean"
-  fakeroot debian/rules clean
+  (set -x; fakeroot debian/rules clean)
 fi
 
-echo "fakeroot debian/rules binary"
-fakeroot debian/rules binary
+(set -x; fakeroot debian/rules binary)

--- a/run.sh
+++ b/run.sh
@@ -2,7 +2,12 @@
 
 set -eu
 
-apt-get install -y devscripts fakeroot python-stdeb
+PYTHON_INTERP=python
+if [ "${WERCKER_PYTHON_STDEB_USE_PYTHON3}" == "true" ]; then
+  PYTHON_INTERP+=3
+fi
+
+apt-get install -y devscripts fakeroot ${PYTHON_INTERP}-stdeb
 
 DEBIAN_SOURCE_DIR="${WERCKER_PYTHON_STDEB_PROJECT_ROOT}/debian/source"
 PYBUILD_DIR="${WERCKER_PYTHON_STDEB_PROJECT_ROOT}/.pybuild"
@@ -22,7 +27,7 @@ fi
 NOW=$(date -u +'%Y%m%dT%H%M%SZ')
 cd ${WERCKER_PYTHON_STDEB_PROJECT_ROOT}
 
-(set -x; python setup.py --command-package=stdeb.command ${WERCKER_PYTHON_STDEB_STDEB_COMMAND})
+(set -x; ${PYTHON_INTERP} setup.py --command-package=stdeb.command ${WERCKER_PYTHON_STDEB_STDEB_COMMAND})
 
 if [ "${WERCKER_PYTHON_STDEB_STDEB_COMMAND}" == "debianize" ]; then
   sed -i -e "s/-1)/-${NOW})/" debian/changelog

--- a/wercker-step.yml
+++ b/wercker-step.yml
@@ -1,5 +1,5 @@
 name: python-stdeb
-version: 0.2.5
+version: 0.2.6
 description: generate debian package using stdeb
 properties:
   project_root:

--- a/wercker-step.yml
+++ b/wercker-step.yml
@@ -22,3 +22,7 @@ properties:
     type: string
     default: debianize
     required: false
+  use_python3:
+    type: string
+    default: "false"
+    required: false


### PR DESCRIPTION
Add use_python3 option so we can use python3 interpreter for setup.py.

Additionally:
* simplify echo of commands
* allow stdeb_command to include options